### PR TITLE
Will create the bushnet networks when started

### DIFF
--- a/cmd/rpi-net-manager/main.go
+++ b/cmd/rpi-net-manager/main.go
@@ -102,6 +102,26 @@ func runMain() error {
 }
 
 func startService() error {
+
+	bushnetConfig := map[string]string{
+		"connection.type":                 "802-11-wireless",
+		"connection.auth-retries":         "2",
+		"connection.autoconnect-priority": "10",
+		"ipv4.route-metric":               "10",
+		"ipv6.route-metric":               "10",
+		"wifi.ssid":                       "bushnet",
+		"wifi-sec.psk":                    "feathers",
+		"wifi-sec.key-mgmt":               "wpa-psk",
+	}
+	if err := netmanagerclient.ModifyNetworkConfig("bushnet", bushnetConfig); err != nil {
+		return err
+	}
+
+	bushnetConfig["wifi.ssid"] = "Bushnet"
+	if err := netmanagerclient.ModifyNetworkConfig("Bushnet", bushnetConfig); err != nil {
+		return err
+	}
+
 	c, done, err := makeNetworkUpdateChan()
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously salt would manage the network files for bushnet but found that sometimes it could get in a state where the bushnet networks would stop working.
Using rpi-net-manager to mange those networks should be more robust and not require salt updates to fix issues.