### PR TITLE
Fix Hotspot for Android (disable pmf)

### DIFF
--- a/cmd/rpi-net-manager/main.go
+++ b/cmd/rpi-net-manager/main.go
@@ -11,8 +11,10 @@ import (
 	"github.com/godbus/dbus/v5"
 )
 
-var version = "<not set>"
-var log = logging.NewLogger("info")
+var (
+	version = "<not set>"
+	log     = logging.NewLogger("info")
+)
 
 type AddNetwork struct {
 	SSID string `arg:"required" help:"the SSID of the network"`
@@ -105,7 +107,6 @@ func runMain() error {
 }
 
 func startService() error {
-
 	bushnetConfig := map[string]string{
 		"connection.type":                 "802-11-wireless",
 		"connection.auth-retries":         "2",
@@ -115,6 +116,7 @@ func startService() error {
 		"wifi.ssid":                       "bushnet",
 		"wifi-sec.psk":                    "feathers",
 		"wifi-sec.key-mgmt":               "wpa-psk",
+		"802-11-wireless-security.pmf":    "disable", // Android has issues with PMF
 	}
 	if err := netmanagerclient.ModifyNetworkConfig("bushnet", bushnetConfig); err != nil {
 		return err

--- a/cmd/rpi-net-manager/network.go
+++ b/cmd/rpi-net-manager/network.go
@@ -272,16 +272,17 @@ func (nsm *networkStateMachine) setupHotspot() error {
 
 	log.Println("Setting up network for hosting a hotspot.")
 	hotspotConfig := map[string]string{
-		"connection.type":      "802-11-wireless",
-		"ifname":               "wlan0",
-		"autoconnect":          "no",
-		"ssid":                 "bushnet",
-		"802-11-wireless.mode": "ap",
-		"802-11-wireless.band": "bg",
-		"ipv4.method":          "manual", // Using 'manual' instead of 'shared' so can configure dnsmasq to not share the internet connection of the modem to connected devices.
-		"wifi-sec.key-mgmt":    "wpa-psk",
-		"wifi-sec.psk":         "feathers",
-		"ipv4.addresses":       router_ip + "/24",
+		"connection.type":              "802-11-wireless",
+		"ifname":                       "wlan0",
+		"autoconnect":                  "no",
+		"ssid":                         "bushnet",
+		"802-11-wireless.mode":         "ap",
+		"802-11-wireless.band":         "bg",
+		"ipv4.method":                  "manual", // Using 'manual' instead of 'shared' so can configure dnsmasq to not share the internet connection of the modem to connected devices.
+		"wifi-sec.key-mgmt":            "wpa-psk",
+		"wifi-sec.psk":                 "feathers",
+		"ipv4.addresses":               router_ip + "/24",
+		"802-11-wireless-security.pmf": "disable", // Android has issues with PMF
 	}
 
 	if err := netmanagerclient.ModifyNetworkConfig(bushnetHotspot, hotspotConfig); err != nil {


### PR DESCRIPTION
Related: https://bugs.launchpad.net/ubuntu/+source/wpa/+bug/1972790 https://askubuntu.com/questions/1421747/wifi-hotspot-from-ubuntu-22-04-not-visible-on-android-12-0